### PR TITLE
Update Trivy scanner to use SARIF format

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -54,11 +54,17 @@ jobs:
       uses: aquasecurity/trivy-action@0.28.0
       with:
         scan-type: "fs"
-        format: 'table'
         exit-code: '1'
         ignore-unfixed: true
         vuln-type: 'os,library'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: 'trivy-results.sarif'
     
     - name: Publish Site
       working-directory: ./src/TrisvagoHotels.Host


### PR DESCRIPTION
Change Trivy scanner output format to SARIF and upload results.